### PR TITLE
Add national teams variables 20250614

### DIFF
--- a/definitions/variable/afolu/agriculture.yaml
+++ b/definitions/variable/afolu/agriculture.yaml
@@ -218,6 +218,6 @@
 - Price|Agriculture|Energy Crops:
     description: Farm-gate price of second-generation bioenergy crops
       (short rotation grasses, short rotation trees)
-    unit: USD_2010/GJ
+    unit: USD_2017/GJ
     weight: Agricultural Production|Crops|Energy Crops
     tier: 1

--- a/definitions/variable/climate/climate.yaml
+++ b/definitions/variable/climate/climate.yaml
@@ -1,0 +1,8 @@
+- Climate|GWP|{Level-3 Species}
+    description: Global warming potential of {Level-3 Species} that is used for
+      variables that have units of CO2-equivalents.
+    unit: ""
+    notes: It is not specified what period the GWP is calculated over (i.e.,
+      whether it is GWP100, GWP20 or some other period). Modelers should use
+      this variable to report whichever GWP has been used to calculate
+      CO2-equivalent emissions in other variables.

--- a/definitions/variable/energy/energy-prices.yaml
+++ b/definitions/variable/energy/energy-prices.yaml
@@ -1,25 +1,25 @@
 - Price|Primary Energy|Biomass:
     description: Producer price for biomass
-    unit: USD_2010/GJ
+    unit: USD_2017/GJ
     tier: 1
     weight: Primary Energy|Biomass
 - Price|Primary Energy|{Primary Fossil Fuel}:
     description: Price for {Primary Fossil Fuel} at global or regional spot markets
-    unit: USD_2010/GJ
+    unit: USD_2017/GJ
     tier: 1
     weight: Primary Energy|{Primary Fossil Fuel}
 
 - Price|Secondary Energy|Electricity:
     definition: Electricity price at the regional wholesale-market,
       i.e. for large-scale consumers
-    unit: USD_2010/GJ
+    unit: USD_2017/GJ
     tier: 1
     weight: Secondary Energy|Electricity
     notes: This price should include the effect of carbon prices.
 - Price|Secondary Energy|{Secondary Fuel Level 2}:
     definition: Price for {Secondary Fuel Level 2} at the regional wholesale market,
       i.e. for large-scale consumers
-    unit: USD_2010/GJ
+    unit: USD_2017/GJ
     tier: 1
     weight: Secondary Energy|{Secondary Fuel Level 2}
     notes: This price should include the effect of carbon prices.
@@ -27,24 +27,24 @@
 - Price|Final Energy|Electricity:
     definition: Electricity price including transmission and distribution costs,
       including carbon prices but not including other taxes
-    unit: USD_2010/GJ
+    unit: USD_2017/GJ
     tier: 1
     weight: Final Energy|Electricity
 - Price|Final Energy|{Secondary Fuel Level 2}:
     definition: Price for {Secondary Fuel Level 2} including transmission and
       distribution costs, including carbon prices but not including other taxes
-    unit: USD_2010/GJ
+    unit: USD_2017/GJ
     tier: 1
     weight: Final Energy|{Secondary Fuel Level 2}
 - Price|Final Energy|{Sector}|Electricity:
     definition: Electricity price including transmission and distribution costs,
       including carbon prices but not including other taxes
-    unit: USD_2010/GJ
+    unit: USD_2017/GJ
     tier: 1
     weight: Final Energy|{Sector}|Electricity
 - Price|Final Energy|{Sector}|{Secondary Fuel Level 2}:
     definition: Price for {Secondary Fuel Level 2} in the {Sector} including transmission
       and distribution costs, including carbon prices but not including other taxes
-    unit: USD_2010/GJ
+    unit: USD_2017/GJ
     tier: 1
     weight: Final Energy|{Sector}|{Secondary Fuel Level 2}

--- a/definitions/variable/environment/water.yaml
+++ b/definitions/variable/environment/water.yaml
@@ -1,6 +1,25 @@
 - Water Withdrawal:
     definition: Total water withdrawals
     unit: km3/yr
+    check-aggregate: true
+    components:
+      - By water source:
+        - Water Withdrawal|Surface Water
+        - Water Withdrawal|Groundwater
+      - By sector:
+        - Water Withdrawal|Industrial Water
+        - Water Withdrawal|Municipal Water
+        - Water Withdrawal|Irrigation
+        - Water Withdrawal|Electricity
+        - Water Withdrawal|Livestock
+
+- Water Withdrawal|Surface Water:
+    definition: Total water withdrawals of surface water
+    unit: km3/yr
+- Water Withdrawal|Groundwater:
+    definition: Total water withdrawals of groundwater
+    unit: km3/yr
+
 - Water Withdrawal|Industrial Water:
     definition: Water withdrawals for the industrial and manufacturing sector
     unit: km3/yr

--- a/definitions/variable/industry/production-prices.yaml
+++ b/definitions/variable/industry/production-prices.yaml
@@ -1,6 +1,6 @@
 - Price|Production|Iron and Steel|{Iron Commodity}:
     description: Price of {Iron Commodity}
-    unit: USD_2010/Mt
+    unit: USD_2017/Mt
     tier: 2
     weight: Production|Iron and Steel|{Iron Commodity}
     navigate: Price|Industry|Iron and Steel|{Iron Commodity}
@@ -8,7 +8,7 @@
 
 - Price|Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}:
     description: Price of {Non-Metallic Minerals Commodity}
-    unit: USD_2010/Mt
+    unit: USD_2017/Mt
     tier: 2
     weight: Production|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}
     navigate: Price|Industry|Non-Metallic Minerals|{Non-Metallic Minerals Commodity}
@@ -16,7 +16,7 @@
 
 - Price|Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}:
     description: Price of {Non-Ferrous Metals Commodity}
-    unit: USD_2010/Mt
+    unit: USD_2017/Mt
     tier: 2
     weight: Production|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}
     navigate: Price|Industry|Non-Ferrous Metals|{Non-Ferrous Metals Commodity}
@@ -24,7 +24,7 @@
 
 - Price|Production|Chemicals|{Chemicals Commodity}:
     description: Price of {Chemicals Commodity}
-    unit: USD_2010/Mt
+    unit: USD_2017/Mt
     tier: 2
     weight: Production|Chemicals|{Chemicals Commodity}
     navigate: Price|Industry|Chemicals|{Chemicals Commodity}

--- a/definitions/variable/macro-economy/consumption.yaml
+++ b/definitions/variable/macro-economy/consumption.yaml
@@ -1,6 +1,6 @@
 - Consumption:
     description: Total consumption of all goods, by all consumers in a region
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
     lower_bound: 0
 - Consumption|{Population Deciles} [Share]:

--- a/definitions/variable/macro-economy/finance.yaml
+++ b/definitions/variable/macro-economy/finance.yaml
@@ -1,8 +1,8 @@
 - Debt:
     description: Total net external debt
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 2
 - Debt|Government:
     description: Total net external public debt
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 2

--- a/definitions/variable/macro-economy/gdp.yaml
+++ b/definitions/variable/macro-economy/gdp.yaml
@@ -1,36 +1,36 @@
 - GDP|MER:
     description: GDP converted to USD at market exchange rate (MER)
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
 - GDP|PPP:
     description: GDP converted to USD using purchasing power parity (PPP)
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
 - Value Added:
     description: Total value added
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
 - Value Added|{Economic Sectors Level 2}:
     description: Value added by the {Economic Sectors Level 2}
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
     navigate: Value Added|{Economic Sectors Level 2}
 - Capital Formation:
     description: Net additions to the physical capital stock
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
 - Expenditure|Government:
     description: Total expenditure by governments
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
 - Expenditure|Households:
     description: Total expenditure by households
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
     navigate: Expenditure|Household
 - Revenue|Government:
     description: Government revenue
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
     engage: Revenue|government
     navigate: Revenue|government

--- a/definitions/variable/macro-economy/investment.yaml
+++ b/definitions/variable/macro-economy/investment.yaml
@@ -1,57 +1,57 @@
 - Investment:
     description: Total economy-wide investments including macro-economic capital stock,
       energy system, R&D, etc.
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
 - Investment|Agriculture:
     description: Investment related to agricultural activity
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
 - Investment|Energy Supply:
     description: Investments in the energy supply system
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
 - Investment|Energy Supply|Extraction|{Primary Fossil Fuel}:
     description: Investments for extraction, transportation and conversion of
       {Primary Fossil Fuel}
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
 - Investment|Energy Supply|Extraction|Uranium:
     description: Investments for extraction, transportation, conversion and enrichment
       of uranium
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
 - Investment|Energy Supply|{Secondary Fuel Level 2}:
     description: Investments for the production of {Secondary Fuel Level 2}
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
     notes: For plants equipped with CCS, the investment in the capturing equipment should
       be included but not the costs related to CO2 transport and storage.
 - Investment|Energy Supply|{Secondary Fuel Level 2}|{CCS}:
     description: Investments for the production of {Secondary Fuel Level 2} {CCS}
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
     notes: For plants equipped with CCS, the investment in the capturing equipment should
       be included but not the costs related to CO2 transport and storage.
 - Investment|Energy Supply|Electricity:
     description: Investments in electricity generation and supply
       including storage and transmission-distribution infrastructure
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
 - Investment|Energy Supply|Electricity|{Electricity Source}:
     description: Investments in electricity generation capacity from {Electricity Source}
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
 - Investment|Energy Supply|Electricity|Storage:
     description: Investments in electricity storage capacity
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 2
     engage: Investment|Energy Supply|Electricity|Electricity Storage
     navigate: Investment|Energy Supply|Electricity|Electricity Storage
 - Investment|Energy Supply|Electricity|Transmission and Distribution:
     description: Investments in electricity transmission and distribution infrastructure
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 2
 
 - Investment|Energy Efficiency:
     description: Investments in efficiency-increasing components of energy demand
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 2

--- a/definitions/variable/macro-economy/macroeconomic_other.yaml
+++ b/definitions/variable/macro-economy/macroeconomic_other.yaml
@@ -1,4 +1,4 @@
 - Capital Stock:
     description: Macroeconomic capital stock
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 2

--- a/definitions/variable/macro-economy/price.yaml
+++ b/definitions/variable/macro-economy/price.yaml
@@ -1,6 +1,6 @@
 - Price|Carbon:
     description: Price of carbon (as reported by the model)
-    unit: USD_2010/t CO2
+    unit: USD_2017/t CO2
     region-aggregation:
       - Price|Carbon [Mean]:
           method: mean
@@ -12,11 +12,11 @@
     check-aggregate: false
 - Price|Carbon [Mean]:
     description: Price of carbon (computed as unweighted mean across regions)
-    unit: USD_2010/t CO2
+    unit: USD_2017/t CO2
     skip-region-aggregation: true
 - Price|Carbon [weighted by Emissions|CO2]:
     description: Price of carbon (weighted by regional CO2 emissions)
-    unit: USD_2010/t CO2
+    unit: USD_2017/t CO2
     skip-region-aggregation: true
     notes: Regional CO2 emissions can turn negative at different points in time, which
        can result in counter-intuitive aggregation results when used as weights for
@@ -27,5 +27,5 @@
        of the share of the global energy system the carbon price is applied to.
 - Price|Carbon [weighted by Final Energy]:
     description: Price of carbon (weighted by final energy consumption across regions)
-    unit: USD_2010/t CO2
+    unit: USD_2017/t CO2
     skip-region-aggregation: true

--- a/definitions/variable/macro-economy/tag_energy-trade-type.yaml
+++ b/definitions/variable/macro-economy/tag_energy-trade-type.yaml
@@ -1,7 +1,7 @@
 - Energy Trade Type:
     - Value:
         description: measured in monetary quantities
-        unit: billion USD_2010/yr
+        unit: billion USD_2017/yr
     - Volume:
         description: measured in physical energy quantities
         unit: EJ/yr

--- a/definitions/variable/macro-economy/trade.yaml
+++ b/definitions/variable/macro-economy/trade.yaml
@@ -1,7 +1,7 @@
 # trade in goods
 - Trade|Goods [Value]:
     description: Net exports of all goods measured in monetary quantities
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     tier: 1
     navigate: Trade
     engage: Trade
@@ -18,7 +18,7 @@
 - Trade|Emissions Allowances [Value]:
     description: Net trade (international sales minus purchases) of GHG emission allowances
       measured in monetary quantities
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     notes: Negative values indicate that purchases (imports) exceed sales (exports).
       At the global level these should add up to zero.
     engage: Trade|Emissions Allowances|Value

--- a/definitions/variable/sdg-indicators/sdg.yaml
+++ b/definitions/variable/sdg-indicators/sdg.yaml
@@ -286,7 +286,7 @@
     shape: Final Energy|Industry|Electricity|Share
 - Intensity|Final Energy:
     description: Final Energy intensity
-    unit: EJ/billion USD_2010
+    unit: EJ/billion USD_2017
     sdg: 7
     weight: GDP|PPP
 - GDP|PPP [Growth Rate per capita]:
@@ -394,11 +394,11 @@
 - Policy Cost|GDP Loss w/o Transfers:
     description: GDP loss without international transfers in a policy scenario compared
       to the corresponding baseline (losses should be reported as positive numbers)
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     sdg: 17
     shape: Policy Cost|GDP Loss|w/o transfers
 - Policy Cost|Transfers:
     description: Net international climate finance transfers (positive for inflow,
       negative for payment)
-    unit: billion USD_2010/yr
+    unit: billion USD_2017/yr
     sdg: 17

--- a/definitions/variable/techno-economic/electricity-generation.yaml
+++ b/definitions/variable/techno-economic/electricity-generation.yaml
@@ -1,13 +1,13 @@
 - Capital Cost|Electricity|{Electricity Source}:
     description: Capital cost of a newly installed plant to generate electricity
       from {Electricity Source}
-    unit: USD_2010/kW
+    unit: USD_2017/kW
     tier: 2
     skip-region-aggregation: true
 - Capital Cost|Electricity|{Electricity Source}|*:
     description: Capital cost of a newly installed plant to generate electricity
       from {Electricity Source} for a specific technology
-    unit: USD_2010/kW
+    unit: USD_2017/kW
     tier: 2
     skip-region-aggregation: true
 - Efficiency|Electricity|{Electricity Source}:

--- a/definitions/variable/techno-economic/other-energy-transformation-technologies.yaml
+++ b/definitions/variable/techno-economic/other-energy-transformation-technologies.yaml
@@ -1,11 +1,11 @@
 - Capital Cost|{Secondary Fuel Level 3}:
     description: Capital cost of a newly installed plant to produce {Secondary Fuel Level 3}
-    unit: USD_2010/kW
+    unit: USD_2017/kW
     skip-region-aggregation: true
 - Capital Cost|{Secondary Fuel Level 3}|*:
     description: Capital cost of a newly installed plant to produce {Secondary Fuel Level 3}
       for a specific technology
-    unit: USD_2010/kW
+    unit: USD_2017/kW
     skip-region-aggregation: true
 - Efficiency|{Secondary Fuel Level 3}:
     description: Conversion efficiency per unit of primary energy of a newly installed


### PR DESCRIPTION
Added custom variables in communication with national teams on 2025-06-16.

This includes custom variables for water withdrawal broken down by surface water and groundwater, as well as variables to report GWP values used to calculate emission variables that are expressed in CO2-equivalents.

This PR also contains an unrelated change that reverts from expressing price/cost/macro variables in USD_2010 back to USD_2017. USD_2017 is the standard in D4.4, but when we integrated the definitions from the `common-definitions` repository, they were all changed to USD_2010.