### PR TITLE
Fixed a typo in the new climate/climate.yaml definition file.

### DIFF
--- a/definitions/variable/climate/climate.yaml
+++ b/definitions/variable/climate/climate.yaml
@@ -1,4 +1,4 @@
-- Climate|GWP|{Level-3 Species}
+- Climate|GWP|{Level-3 Species}:
     description: Global warming potential of {Level-3 Species} that is used for
       variables that have units of CO2-equivalents.
     unit: ""


### PR DESCRIPTION
Forgot a colon, and then didn't check the results of the GitHub actions before mering PR #1 . That PR therefore contains an error, the fix (hopefully) is in this PR.